### PR TITLE
Multiple parents functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.0-alpha",
       "license": "CAL-1.0",
       "dependencies": {
+        "d3-dag": "^0.11.5",
         "pm2": "^5.1.1"
       }
     },
@@ -486,6 +487,28 @@
       "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
       "integrity": "sha1-lQL18BVKLVoioCPnn3HMk2+m728="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dag": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/d3-dag/-/d3-dag-0.11.5.tgz",
+      "integrity": "sha512-sNHvYqjzDlvV2fyEkoOCSuLs2GeWliIg7pJcAiKXgtUSxl0kIX0C2q1J8JzzA9CQWptKxYtzxFCXiKptTW8qsQ==",
+      "dependencies": {
+        "d3-array": "^3.1.6",
+        "fastpriorityqueue": "0.7.2",
+        "javascript-lp-solver": "0.4.24",
+        "quadprog": "^1.6.1"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -634,6 +657,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "node_modules/fastpriorityqueue": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.2.tgz",
+      "integrity": "sha512-5DtIKh6vtOmEGkYdEPNNb+mxeYCnBiKbK3s4gq52l6cX8I5QaTDWWw0Wx/iYo80fVOblSycHu1/iJeqeNxG8Jw=="
     },
     "node_modules/fclone": {
       "version": "1.0.11",
@@ -897,6 +925,14 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -950,6 +986,11 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/javascript-lp-solver": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/javascript-lp-solver/-/javascript-lp-solver-0.4.24.tgz",
+      "integrity": "sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA=="
     },
     "node_modules/js-git": {
       "version": "0.7.8",
@@ -1387,6 +1428,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/quadprog": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/quadprog/-/quadprog-1.6.1.tgz",
+      "integrity": "sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw==",
+      "engines": {
+        "node": ">=8.x"
+      }
     },
     "node_modules/raw-body": {
       "version": "2.4.1",
@@ -2193,6 +2242,25 @@
       "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
       "integrity": "sha1-lQL18BVKLVoioCPnn3HMk2+m728="
     },
+    "d3-array": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+      "requires": {
+        "internmap": "1 - 2"
+      }
+    },
+    "d3-dag": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/d3-dag/-/d3-dag-0.11.5.tgz",
+      "integrity": "sha512-sNHvYqjzDlvV2fyEkoOCSuLs2GeWliIg7pJcAiKXgtUSxl0kIX0C2q1J8JzzA9CQWptKxYtzxFCXiKptTW8qsQ==",
+      "requires": {
+        "d3-array": "^3.1.6",
+        "fastpriorityqueue": "0.7.2",
+        "javascript-lp-solver": "0.4.24",
+        "quadprog": "^1.6.1"
+      }
+    },
     "data-uri-to-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
@@ -2293,6 +2361,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fastpriorityqueue": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/fastpriorityqueue/-/fastpriorityqueue-0.7.2.tgz",
+      "integrity": "sha512-5DtIKh6vtOmEGkYdEPNNb+mxeYCnBiKbK3s4gq52l6cX8I5QaTDWWw0Wx/iYo80fVOblSycHu1/iJeqeNxG8Jw=="
     },
     "fclone": {
       "version": "1.0.11",
@@ -2495,6 +2568,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -2533,6 +2611,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "javascript-lp-solver": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/javascript-lp-solver/-/javascript-lp-solver-0.4.24.tgz",
+      "integrity": "sha512-5edoDKnMrt/u3M6GnZKDDIPxOyFOg+WrwDv8mjNiMC2DePhy2H9/FFQgf4ggywaXT1utvkxusJcjQUER72cZmA=="
     },
     "js-git": {
       "version": "0.7.8",
@@ -2889,6 +2972,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "quadprog": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/quadprog/-/quadprog-1.6.1.tgz",
+      "integrity": "sha512-fN5Jkcjlln/b3pJkseDKREf89JkKIyu6cKIVXisgL6ocKPQ0yTp9n6NZUAq3otEPPw78WZMG9K0o9WsfKyMWJw=="
     },
     "raw-body": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "Connor Turland <connor@sprillow.com>",
   "license": "CAL-1.0",
   "dependencies": {
+    "d3-dag": "^0.11.5",
     "pm2": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "author": "Connor Turland <connor@sprillow.com>",
   "license": "CAL-1.0",
   "dependencies": {
-    "d3-dag": "^0.11.5",
     "pm2": "^5.1.1"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "@holochain/client": "0.12.0",
     "@material-ui/core": "^4.6.1",
     "@tweenjs/tween.js": "^18.6.4",
+    "d3-dag": "^0.11.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "buffer": "^6.0.3",
     "core-js": "^3.6.5",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,9 @@
 {
   "name": "acorn-ui",
   "version": "5.0.0-alpha",
+  "browser": {
+    "child_process": false
+  },
   "devDependencies": {
     "@babel/core": "^7.14.0",
     "@babel/preset-env": "^7.5.5",

--- a/web/src/components/MapViewContextMenu/MapViewContextMenu.tsx
+++ b/web/src/components/MapViewContextMenu/MapViewContextMenu.tsx
@@ -64,14 +64,16 @@ const Checkbox: React.FC<CheckboxProps> = ({
       text: 'Expand Outcome',
       onClick: wrappedExpandOutcome,
     })
-  } else if (hasChildren) {
-    actions.push({
-      key: 'collapse',
-      icon: 'leaf.svg',
-      text: 'Collapse Outcome',
-      onClick: wrappedCollapseOutcome,
-    })
   }
+  // DISABLED: collapsing outcomes
+  // else if (hasChildren) {
+  // actions.push({
+  //   key: 'collapse',
+  //   icon: 'leaf.svg',
+  //   text: 'Collapse Outcome',
+  //   onClick: wrappedCollapseOutcome,
+  // })
+  // }
 
   return (
     <div

--- a/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.component.tsx
+++ b/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.component.tsx
@@ -38,10 +38,6 @@ export type MapViewOutcomeTitleFormConnectorStateProps = {
   // (optional) the relation (relation_as_{child|parent}) between the two
   // in the case of creating an Outcome
   relation: RelationInput
-  // (optional) the address of an existing connection that
-  // indicates this Outcome as the child of another (a.k.a has a parent)
-  // ASSUMPTION: one parent
-  existingParentConnectionAddress: ActionHashB64
 }
 
 export type MapViewOutcomeTitleFormConnectorDispatchProps = {
@@ -65,7 +61,7 @@ const MapViewOutcomeTitleForm: React.FC<MapViewOutcomeTitleFormProps> = ({
   content,
   fromAddress,
   relation,
-  existingParentConnectionAddress,
+
   leftConnectionXPosition,
   topConnectionYPosition,
   updateContent,

--- a/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.component.tsx
+++ b/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.component.tsx
@@ -121,13 +121,6 @@ const MapViewOutcomeTitleForm: React.FC<MapViewOutcomeTitleFormProps> = ({
   }
 
   const innerCreateOutcomeWithConnection = async () => {
-    // if we are replacing an connection with this one
-    // delete the existing connection first
-    // ASSUMPTION: one parent
-    if (existingParentConnectionAddress) {
-      await deleteConnection(existingParentConnectionAddress)
-    }
-
     // dispatch the action to create an Outcome
     // with the contents from the form
     // inserted into it

--- a/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.connector.ts
+++ b/web/src/components/MapViewOutcomeTitleForm/MapViewOutcomeTitleForm.connector.ts
@@ -1,20 +1,24 @@
 import { connect } from 'react-redux'
 import { RootState } from '../../redux/reducer'
-import {
-  createOutcomeWithConnection,
-} from '../../redux/persistent/projects/outcomes/actions'
+import { createOutcomeWithConnection } from '../../redux/persistent/projects/outcomes/actions'
 import { deleteConnection } from '../../redux/persistent/projects/connections/actions'
 import {
   closeOutcomeForm,
   updateContent,
 } from '../../redux/ephemeral/outcome-form/actions'
-import MapViewOutcomeTitleForm, { MapViewOutcomeTitleFormConnectorDispatchProps, MapViewOutcomeTitleFormOwnProps } from './MapViewOutcomeTitleForm.component'
+import MapViewOutcomeTitleForm, {
+  MapViewOutcomeTitleFormConnectorDispatchProps,
+  MapViewOutcomeTitleFormOwnProps,
+} from './MapViewOutcomeTitleForm.component'
 import ProjectsZomeApi from '../../api/projectsApi'
 import { getAppWs } from '../../hcWebsockets'
 import { cellIdFromString } from '../../utils'
 import { ActionHashB64, Option } from '../../types/shared'
 import { LinkedOutcomeDetails, Outcome } from '../../types'
-import { selectOutcome, unselectAll } from '../../redux/ephemeral/selection/actions'
+import {
+  selectOutcome,
+  unselectAll,
+} from '../../redux/ephemeral/selection/actions'
 import { animatePanAndZoom } from '../../redux/ephemeral/viewport/actions'
 import { LAYOUT_ANIMATION_DURATION_MS } from '../../constants'
 
@@ -35,8 +39,6 @@ function mapStateToProps(state: RootState) {
         // these three all relate to each other
         fromAddress,
         relation,
-        // ASSUMPTION: one parent
-        existingParentConnectionAddress, // this is optional though
       },
     },
   } = state
@@ -50,10 +52,6 @@ function mapStateToProps(state: RootState) {
     // between the potential fromAddress Outcome
     // and a new Outcome to be created
     relation,
-    // optional, the address of an existing connection that
-    // indicates this Outcome as the child of another (a.k.a has a parent)
-    // ASSUMPTION: one parent
-    existingParentConnectionAddress,
     content,
     leftConnectionXPosition: leftConnectionXPosition,
     topConnectionYPosition: topConnectionYPosition,
@@ -64,7 +62,10 @@ function mapStateToProps(state: RootState) {
 // Designed to pass functions into components which are already wrapped as
 // action dispatchers for redux action types
 
-function mapDispatchToProps(dispatch, ownProps: MapViewOutcomeTitleFormOwnProps): MapViewOutcomeTitleFormConnectorDispatchProps {
+function mapDispatchToProps(
+  dispatch,
+  ownProps: MapViewOutcomeTitleFormOwnProps
+): MapViewOutcomeTitleFormConnectorDispatchProps {
   const { projectId: cellIdString } = ownProps
   const cellId = cellIdFromString(cellIdString)
   return {
@@ -82,7 +83,10 @@ function mapDispatchToProps(dispatch, ownProps: MapViewOutcomeTitleFormOwnProps)
       await projectsZomeApi.connection.delete(cellId, actionHash)
       return dispatch(deleteConnection(cellIdString, actionHash))
     },
-    createOutcomeWithConnection: async (entry: Outcome, maybeLinkedOutcome: Option<LinkedOutcomeDetails>) => {
+    createOutcomeWithConnection: async (
+      entry: Outcome,
+      maybeLinkedOutcome: Option<LinkedOutcomeDetails>
+    ) => {
       const appWebsocket = await getAppWs()
       const projectsZomeApi = new ProjectsZomeApi(appWebsocket)
       const outcomeWithConnection = await projectsZomeApi.outcome.createOutcomeWithConnection(
@@ -92,19 +96,19 @@ function mapDispatchToProps(dispatch, ownProps: MapViewOutcomeTitleFormOwnProps)
           maybeLinkedOutcome,
         }
       )
-      dispatch(
-        createOutcomeWithConnection(cellIdString, outcomeWithConnection)
-      )
+      dispatch(createOutcomeWithConnection(cellIdString, outcomeWithConnection))
       // Re. the timeout...
       // it is necessary because an animation
       // runs in layout.ts that initially moves the position
-      // of the Outcome itself. Before animating to the 
+      // of the Outcome itself. Before animating to the
       const ADDITIONAL_WAIT_BUFFER_MS = 40
       setTimeout(() => {
         dispatch(unselectAll())
         dispatch(selectOutcome(outcomeWithConnection.outcome.actionHash))
         // `false` here means DONT change the scale, only the translate
-        dispatch(animatePanAndZoom(outcomeWithConnection.outcome.actionHash, false))
+        dispatch(
+          animatePanAndZoom(outcomeWithConnection.outcome.actionHash, false)
+        )
       }, LAYOUT_ANIMATION_DURATION_MS + ADDITIONAL_WAIT_BUFFER_MS)
     },
     closeOutcomeForm: () => {

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.component.tsx
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.component.tsx
@@ -34,8 +34,6 @@ const OutcomeConnectorHtml = ({
 
 const OutcomeConnector = ({
   activeProject,
-  ownExistingParentConnectionAddress,
-  presetExistingParentConnectionAddress,
   fromAddress,
   relation,
   toAddress,
@@ -99,13 +97,7 @@ const OutcomeConnector = ({
       setOutcomeConnectorFrom(
         address,
         direction,
-        validity(address, connections, outcomeActionHashes),
-        // we don't think about overriding the existing
-        // parent when it comes to children, since it can have many
-        // ASSUMPTION: one parent
-        direction === RELATION_AS_CHILD
-          ? ownExistingParentConnectionAddress
-          : undefined
+        validity(address, connections, outcomeActionHashes)
       )
     }
   }
@@ -177,7 +169,6 @@ const OutcomeConnectors = ({
   fromAddress,
   relation,
   toAddress,
-  existingParentConnectionAddress,
   connectorAddresses,
   collapsedOutcomes,
   setOutcomeConnectorFrom,
@@ -206,12 +197,6 @@ const OutcomeConnectors = ({
             fromAddress={fromAddress}
             relation={relation}
             toAddress={toAddress}
-            ownExistingParentConnectionAddress={
-              hasParent && hasParent.actionHash
-            }
-            presetExistingParentConnectionAddress={
-              existingParentConnectionAddress
-            }
             address={connectorAddress}
             setOutcomeConnectorFrom={setOutcomeConnectorFrom}
             setOutcomeConnectorTo={setOutcomeConnectorTo}

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.component.tsx
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.component.tsx
@@ -114,8 +114,6 @@ const OutcomeConnector = ({
       fromAddress,
       relation,
       toAddress,
-      // ASSUMPTION: one parent
-      presetExistingParentConnectionAddress,
       activeProject,
       dispatch
     )

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
@@ -35,6 +35,16 @@ function mapStateToProps(state: RootState) {
     connectorAddresses = [hoveredOutcomeAddress]
   }
 
+  // remove any connections that are already in place
+  connectorAddresses = connectorAddresses.filter((address) => {
+    return !Object.values(connections).find((connection) => {
+      return (
+        connection.childActionHash === fromAddress &&
+        connection.parentActionHash === address
+      )
+    })
+  })
+
   return {
     activeProject,
     projectTags,

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
@@ -14,13 +14,7 @@ function mapStateToProps(state: RootState) {
       viewport: { translate, scale },
       layout: { coordinates, dimensions },
       hover: { hoveredOutcome: hoveredOutcomeAddress },
-      outcomeConnector: {
-        fromAddress,
-        relation,
-        toAddress,
-        existingParentConnectionAddress,
-        validToAddresses,
-      },
+      outcomeConnector: { fromAddress, relation, toAddress, validToAddresses },
       selection: { selectedOutcomes },
     },
   } = state
@@ -52,7 +46,6 @@ function mapStateToProps(state: RootState) {
     fromAddress,
     relation,
     toAddress,
-    existingParentConnectionAddress,
     connectorAddresses,
     collapsedOutcomes,
   }

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
@@ -27,7 +27,7 @@ function mapStateToProps(state: RootState) {
   if (fromAddress) {
     // connector addresses includes the outcome we are connecting from
     // to all the possible outcomes we can connect to validly
-    connectorAddresses = validToAddresses
+    connectorAddresses = [fromAddress, ...validToAddresses]
   }
   // don't allow the connection connectors when we have multiple outcomes selected
   // as it doesn't blend well with the user interface, or make sense at that point

--- a/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
+++ b/web/src/components/OutcomeConnectors/OutcomeConnectors.connector.ts
@@ -27,7 +27,7 @@ function mapStateToProps(state: RootState) {
   if (fromAddress) {
     // connector addresses includes the outcome we are connecting from
     // to all the possible outcomes we can connect to validly
-    connectorAddresses = [fromAddress].concat(validToAddresses)
+    connectorAddresses = validToAddresses
   }
   // don't allow the connection connectors when we have multiple outcomes selected
   // as it doesn't blend well with the user interface, or make sense at that point

--- a/web/src/drawing/index.ts
+++ b/web/src/drawing/index.ts
@@ -12,13 +12,8 @@ import drawConnection, {
 import drawOverlay from './drawOverlay'
 import drawSelectBox from './drawSelectBox'
 import drawEntryPoints from './drawEntryPoints'
-import {
-  RELATION_AS_CHILD,
-} from '../redux/ephemeral/outcome-connector/actions'
-import {
-  getOutcomeHeight,
-  getOutcomeWidth,
-} from './dimensions'
+import { RELATION_AS_CHILD } from '../redux/ephemeral/outcome-connector/actions'
+import { getOutcomeHeight, getOutcomeWidth } from './dimensions'
 import {
   ComputedOutcome,
   ComputedSimpleAchievementStatus,
@@ -31,7 +26,10 @@ import { ProjectConnectionsState } from '../redux/persistent/projects/connection
 import { ProjectEntryPointsState } from '../redux/persistent/projects/entry-points/reducer'
 import { ProjectOutcomeMembersState } from '../redux/persistent/projects/outcome-members/reducer'
 import { getPlaceholderOutcome } from './drawOutcome/placeholderOutcome'
-import { CoordinatesState, DimensionsState } from '../redux/ephemeral/layout/state-type'
+import {
+  CoordinatesState,
+  DimensionsState,
+} from '../redux/ephemeral/layout/state-type'
 
 function setupCanvas(canvas) {
   // Get the device pixel ratio, falling back to 1.
@@ -173,17 +171,6 @@ function render(
     */
   // render each connection to the canvas, basing it off the rendering coordinates of the parent and child nodes
   connectionsAsArray.forEach(function (connection) {
-    // if in the pending re-parenting mode for the child card of an existing connection,
-    // temporarily omit/hide the existing connection from view
-    // ASSUMPTION: one parent
-    const pendingReParent =
-      (outcomeConnectorFromAddress === connection.childActionHash &&
-        outcomeConnectorRelation === RELATION_AS_CHILD) ||
-      (outcomeFormIsOpen &&
-        outcomeFormFromActionHash === connection.childActionHash &&
-        outcomeFormRelation === RELATION_AS_CHILD)
-    if (pendingReParent) return
-
     const childCoords = coordinates[connection.childActionHash]
     const parentCoords = coordinates[connection.parentActionHash]
     const childOutcome = outcomes[connection.childActionHash]

--- a/web/src/drawing/layoutFormula.ts
+++ b/web/src/drawing/layoutFormula.ts
@@ -94,18 +94,28 @@ function layoutForGraph(
   // add all the nodes with connections
   Object.keys(connections).forEach((hash) => {
     const connection = connections[hash]
+
     if (
-      checkOutcomeAgainstViewingFilters(
+      !checkOutcomeAgainstViewingFilters(
         outcomes[connection.parentActionHash],
         hiddenSmalls,
         hiddenAchieved
-      )
+      ) || // parent is hidden
+      !checkOutcomeAgainstViewingFilters(
+        outcomes[connection.childActionHash],
+        hiddenSmalls,
+        hiddenAchieved
+      ) || // child is hidden
+      projectCollapsedOutcomes[connection.parentActionHash] || // parent is collapsed
+      projectCollapsedOutcomes[connection.childActionHash] // child is collapsed
     ) {
-      nodeConnections.push([
-        connection.parentActionHash,
-        connection.childActionHash,
-      ])
+      return
     }
+
+    nodeConnections.push([
+      connection.parentActionHash,
+      connection.childActionHash,
+    ])
   })
 
   // add all the nodes without connections

--- a/web/src/drawing/layoutFormula.ts
+++ b/web/src/drawing/layoutFormula.ts
@@ -1,4 +1,3 @@
-import * as flextree from 'd3-flextree'
 import { getOutcomeWidth, getOutcomeHeight } from './dimensions'
 import {
   ComputedOutcome,
@@ -7,14 +6,16 @@ import {
   Tag,
 } from '../types'
 import { ActionHashB64, WithActionHash } from '../types/shared'
-import { ProjectComputedOutcomes } from '../context/ComputedOutcomeContext'
 import {
   CoordinatesState,
   DimensionsState,
   LayoutState,
 } from '../redux/ephemeral/layout/state-type'
-
-const fl = flextree.flextree
+import { connect } from 'd3-dag/dist/dag/create'
+import { sugiyama } from 'd3-dag'
+import { greedy } from 'd3-dag/dist/sugiyama/coord/greedy'
+import { coffmanGraham } from 'd3-dag/dist/sugiyama/layering/coffman-graham'
+import { Graph } from '../redux/persistent/projects/outcomes/outcomesAsGraph'
 
 const VERTICAL_SPACING = 100
 
@@ -76,88 +77,81 @@ function getBoundingRec(
 
 export { getBoundingRec }
 
-function layoutForTree(
-  tree: ComputedOutcome,
-  allOutcomeDimensions: DimensionsState,
+function layoutForGraph(
+  graph: Graph,
   projectCollapsedOutcomes: {
     [outcomeActionHash: ActionHashB64]: boolean
   },
   hiddenSmalls: boolean,
   hiddenAchieved: boolean
 ): CoordinatesState {
-  // create a graph
-  const layout = fl().spacing((nodeA, nodeB) => {
-    return nodeA.path(nodeB).length * 40
-  })
-
-  const layoutTree = {}
-  // use recursion to add each outcome as a node in the graph
-  function addOutcome(outcome: ComputedOutcome, node: any, level: number) {
-    let numDescendants = 0
-    node.children = []
-    // Skip over the Outcome if it is included in the list
-    // of collapsed Outcomes
-    if (!projectCollapsedOutcomes[outcome.actionHash]) {
-      outcome.children.forEach((childOutcome) => {
-        const childNode = {}
-        // filter out children who don't match the viewing filter criteria
-        if (
-          checkOutcomeAgainstViewingFilters(
-            childOutcome,
-            hiddenSmalls,
-            hiddenAchieved
-          )
-        ) {
-          const descendantCount = addOutcome(childOutcome, childNode, level + 1)
-          node.children.push(childNode)
-          numDescendants += descendantCount + 1
-        }
-      })
-    }
-
-    const width = allOutcomeDimensions[outcome.actionHash].width
-    // to create the dynamic vertical height, we apply
-    // a power law to the number of descendants, with a heightened baseline
-    // because the number of descendants is a good measure of how wide this tree
-    // might be
-    const height =
-      allOutcomeDimensions[outcome.actionHash].height +
-      (numDescendants > 0 ? Math.pow(numDescendants + 25, 1.5) : 60) +
-      VERTICAL_SPACING
-
-    node.actionHash = outcome.actionHash
-    node.size = [width, height]
-
-    return numDescendants
-  }
-  // kick off the recursion
-  addOutcome(tree, layoutTree, 1)
-
-  const flTree = layout.hierarchy(layoutTree)
   // run the layout algorithm, which will set an x and y property onto
   // each node
-  layout(flTree)
-  // create a coordinates object
-  const coordinates = {}
-  // update the coordinates object
-  flTree.each((node) => {
-    // coordinates will represent the top left,
-    // but as-is they represent the center, so re-adjust them by half
-    // the width of the outcome
-    coordinates[node.data.actionHash] = {
-      x: node.x - node.size[0] / 2,
-      y: node.y,
+  const nodeConnections: string[][] = []
+  const connections = graph.connections
+  const outcomes = graph.outcomes.computedOutcomesKeyed
+
+  // add all the nodes with connections
+  Object.keys(connections).forEach((hash) => {
+    const connection = connections[hash]
+    if (
+      checkOutcomeAgainstViewingFilters(
+        outcomes[connection.parentActionHash],
+        hiddenSmalls,
+        hiddenAchieved
+      )
+    ) {
+      nodeConnections.push([
+        connection.parentActionHash,
+        connection.childActionHash,
+      ])
     }
   })
+
+  // add all the nodes without connections
+  Object.keys(outcomes).forEach((hash) => {
+    const outcome = outcomes[hash]
+    if (
+      !nodeConnections.find(
+        (nodeConnection) =>
+          nodeConnection[0] === outcome.actionHash ||
+          nodeConnection[1] === outcome.actionHash
+      ) &&
+      checkOutcomeAgainstViewingFilters(outcome, hiddenSmalls, hiddenAchieved)
+    ) {
+      nodeConnections.push([outcome.actionHash, outcome.actionHash])
+    }
+  })
+
+  const create = connect().single(true) // allow single nodes without connections
+  const dag = create(nodeConnections as any)
+  const dagLayout = sugiyama()
+    // NOTE: make the width and height dynamic based on the card dimensions
+    .nodeSize((node) => (node === undefined ? [0, 0] : [750, 500]))
+    // NOTE: might be useful to expose these two properties to the user
+    .coord(greedy())
+  // .layering(coffmanGraham())
+
+  dagLayout(dag)
+
+  // create the coordinates
+  const coordinates = {}
+  for (const node of dag) {
+    coordinates[node.data.id] = {
+      x: node.x,
+      y: node.y,
+    }
+  }
+
   return coordinates
 }
 
 export default function layoutFormula(
-  trees: ProjectComputedOutcomes,
+  graph: Graph,
   zoomLevel: number,
   projectTags: WithActionHash<Tag>[],
-  projectCollapsedOutcomes: {
-    [outcomeActionHash: ActionHashB64]: boolean
+  collapsedOutcomes: {
+    [outcomeActionHash: string]: boolean
   },
   hiddenSmalls: boolean,
   hiddenAchieved: boolean
@@ -171,87 +165,31 @@ export default function layoutFormula(
   const allOutcomeDimensions: {
     [actionHash: ActionHashB64]: { width: number; height: number }
   } = {}
-  Object.keys(trees.computedOutcomesKeyed).forEach((outcomeActionHash) => {
-    const outcome = trees.computedOutcomesKeyed[outcomeActionHash]
-    const width = getOutcomeWidth({ outcome, zoomLevel })
-    const height = getOutcomeHeight({
-      ctx,
-      outcome,
-      zoomLevel,
-      width,
-      projectTags,
-    })
-    allOutcomeDimensions[outcomeActionHash] = {
-      width,
-      height,
-    }
-  })
 
-  // based on the dimensions, determine what the layout of each
-  // distinct tree will be
-  const layouts = trees.computedOutcomesAsTree
-    .filter((computedOutcome) => {
-      // filter out trees which have been hidden
-      return checkOutcomeAgainstViewingFilters(
-        computedOutcome,
-        hiddenSmalls,
-        hiddenAchieved
-      )
-    })
-    .map((tree) => ({
-      outcome: tree,
-      layout: layoutForTree(
-        tree,
-        allOutcomeDimensions,
-        projectCollapsedOutcomes,
-        hiddenSmalls,
-        hiddenAchieved
-      ),
-    }))
-  const HORIZONTAL_TREE_SPACING = 100
-  // coordinates will be adjusted each time through this iteration
-  layouts.forEach((tree, index) => {
-    // in the case of the first one, let it stay where it is
-    if (index === 0) {
-      const adjusted: CoordinatesState = {}
-      const offsetFromZero = tree.layout[tree.outcome.actionHash].y
-      Object.keys(tree.layout).forEach((coordKey) => {
-        adjusted[coordKey] = {
-          x: tree.layout[coordKey].x,
-          y: tree.layout[coordKey].y - offsetFromZero,
-        }
+  Object.keys(graph.outcomes.computedOutcomesKeyed).forEach(
+    (outcomeActionHash) => {
+      const outcome = graph.outcomes.computedOutcomesKeyed[outcomeActionHash]
+      const width = getOutcomeWidth({ outcome, zoomLevel })
+      const height = getOutcomeHeight({
+        ctx,
+        outcome,
+        zoomLevel,
+        width,
+        projectTags,
       })
-      coordinates = {
-        ...adjusted,
-      }
-    } else {
-      // in the case of all the rest, push it right, according to wherever the last one was positioned + spacing
-      const [_ltop, lastTreeRight, _lbottom, _lleft] = getBoundingRec(
-        layouts[index - 1].outcome,
-        coordinates,
-        allOutcomeDimensions
-      )
-      const [_ttop, _tright, _tbottom, thisTreeLeft] = getBoundingRec(
-        tree.outcome,
-        tree.layout,
-        allOutcomeDimensions
-      )
-      const adjusted: CoordinatesState = {}
-      const yOffset = -1 * tree.layout[tree.outcome.actionHash].y
-      const xOffset = lastTreeRight - thisTreeLeft + HORIZONTAL_TREE_SPACING
-      Object.keys(tree.layout).forEach((coordKey) => {
-        // adjust the coordinate by the xOffset and the yOffset
-        adjusted[coordKey] = {
-          x: xOffset + tree.layout[coordKey].x,
-          y: yOffset + tree.layout[coordKey].y,
-        }
-      })
-      coordinates = {
-        ...coordinates,
-        ...adjusted,
+      allOutcomeDimensions[outcomeActionHash] = {
+        width,
+        height,
       }
     }
-  })
+  )
+
+  coordinates = layoutForGraph(
+    graph,
+    collapsedOutcomes,
+    hiddenSmalls,
+    hiddenAchieved
+  )
 
   return {
     coordinates,

--- a/web/src/drawing/layoutFormula.ts
+++ b/web/src/drawing/layoutFormula.ts
@@ -17,8 +17,6 @@ import { greedy } from 'd3-dag/dist/sugiyama/coord/greedy'
 import { coffmanGraham } from 'd3-dag/dist/sugiyama/layering/coffman-graham'
 import { Graph } from '../redux/persistent/projects/outcomes/outcomesAsGraph'
 
-const VERTICAL_SPACING = 100
-
 function checkOutcomeAgainstViewingFilters(
   outcome: ComputedOutcome,
   hiddenSmalls: boolean,
@@ -132,6 +130,9 @@ function layoutForGraph(
       nodeConnections.push([outcome.actionHash, outcome.actionHash])
     }
   })
+
+  // if there are no nodes, return an empty object
+  if (!nodeConnections.length) return {}
 
   const create = connect().single(true) // allow single nodes without connections
   const dag = create(nodeConnections as any)

--- a/web/src/drawing/layoutFormula.ts
+++ b/web/src/drawing/layoutFormula.ts
@@ -153,12 +153,16 @@ function layoutForGraph(
 
   dagLayout(dag)
 
-  // create the coordinates
+  // define the coordinates of each node
   const coordinates = {}
   for (const node of dag) {
+    const width = allOutcomeDimensions[node.data.id].width
+    const height = allOutcomeDimensions[node.data.id].height
     coordinates[node.data.id] = {
-      x: node.x,
-      y: node.y,
+      // transform the coordinates so that the origin is at the top
+      // left corner of the outcome
+      x: node.x - width / 2,
+      y: node.y - height / 2,
     }
   }
 

--- a/web/src/drawing/layoutFormula.ts
+++ b/web/src/drawing/layoutFormula.ts
@@ -12,7 +12,7 @@ import {
   LayoutState,
 } from '../redux/ephemeral/layout/state-type'
 import { connect } from 'd3-dag/dist/dag/create'
-import { sugiyama } from 'd3-dag'
+import { DagNode, sugiyama } from 'd3-dag'
 import { greedy } from 'd3-dag/dist/sugiyama/coord/greedy'
 import { coffmanGraham } from 'd3-dag/dist/sugiyama/layering/coffman-graham'
 import { Graph } from '../redux/persistent/projects/outcomes/outcomesAsGraph'
@@ -77,6 +77,7 @@ export { getBoundingRec }
 
 function layoutForGraph(
   graph: Graph,
+  allOutcomeDimensions: DimensionsState,
   projectCollapsedOutcomes: {
     [outcomeActionHash: ActionHashB64]: boolean
   },
@@ -137,8 +138,15 @@ function layoutForGraph(
   const create = connect().single(true) // allow single nodes without connections
   const dag = create(nodeConnections as any)
   const dagLayout = sugiyama()
-    // NOTE: make the width and height dynamic based on the card dimensions
-    .nodeSize((node) => (node === undefined ? [0, 0] : [750, 500]))
+    .nodeSize((node: any) => {
+      // width and height, plus some extra padding
+      const width =
+        node === undefined ? 0 : allOutcomeDimensions[node.data.id].width + 200
+      const height =
+        node === undefined ? 0 : allOutcomeDimensions[node.data.id].height + 200
+
+      return [width, height]
+    })
     // NOTE: might be useful to expose these two properties to the user
     .coord(greedy())
   // .layering(coffmanGraham())
@@ -197,6 +205,7 @@ export default function layoutFormula(
 
   coordinates = layoutForGraph(
     graph,
+    allOutcomeDimensions,
     collapsedOutcomes,
     hiddenSmalls,
     hiddenAchieved

--- a/web/src/event-listeners/index.ts
+++ b/web/src/event-listeners/index.ts
@@ -561,8 +561,6 @@ export default function setupEventListeners(
         fromAddress,
         relation,
         toAddress,
-        // ASSUMPTION: one parent
-        existingParentConnectionAddress,
         activeProject,
         store.dispatch
       )

--- a/web/src/event-listeners/index.ts
+++ b/web/src/event-listeners/index.ts
@@ -86,21 +86,19 @@ let platform =
 const isMacish = macOsPattern.test(platform)
 const operatingSystemModifier = isMacish ? 'metaKey' : 'ctrlKey'
 
-// ASSUMPTION: one parent (existingParentConnectionAddress)
+// ASSUMPTION: one parent (
 function handleMouseUpForOutcomeForm({
   state,
   event,
   store,
   fromAddress,
   relation,
-  existingParentConnectionAddress,
 }: {
   state: RootState
   event: MouseEvent
   store: any // redux store, for the sake of dispatch
   fromAddress?: ActionHashB64
   relation?: RelationInput
-  existingParentConnectionAddress?: ActionHashB64
 }) {
   const calcedPoint = coordsPageToCanvas(
     {
@@ -111,15 +109,8 @@ function handleMouseUpForOutcomeForm({
     state.ui.viewport.scale
   )
   store.dispatch(
-    // ASSUMPTION: one parent (existingParentConnectionAddress)
-    openOutcomeForm(
-      calcedPoint.x,
-      calcedPoint.y,
-      null,
-      fromAddress,
-      relation,
-      existingParentConnectionAddress
-    )
+    // ASSUMPTION: one parent (
+    openOutcomeForm(calcedPoint.x, calcedPoint.y, null, fromAddress, relation)
   )
 }
 
@@ -544,13 +535,8 @@ export default function setupEventListeners(
 
   function canvasMouseup(event: MouseEvent) {
     const state = store.getState()
-    // ASSUMPTION: one parent (existingParentConnectionAddress)
-    const {
-      fromAddress,
-      relation,
-      toAddress,
-      existingParentConnectionAddress,
-    } = state.ui.outcomeConnector
+    // ASSUMPTION: one parent (
+    const { fromAddress, relation, toAddress } = state.ui.outcomeConnector
     const { activeProject } = state.ui
     if (fromAddress) {
       // covers the case where we are hovered over an Outcome
@@ -573,7 +559,6 @@ export default function setupEventListeners(
           store,
           fromAddress,
           relation,
-          existingParentConnectionAddress,
         })
       }
     }

--- a/web/src/event-listeners/index.ts
+++ b/web/src/event-listeners/index.ts
@@ -86,7 +86,6 @@ let platform =
 const isMacish = macOsPattern.test(platform)
 const operatingSystemModifier = isMacish ? 'metaKey' : 'ctrlKey'
 
-// ASSUMPTION: one parent (
 function handleMouseUpForOutcomeForm({
   state,
   event,
@@ -109,7 +108,6 @@ function handleMouseUpForOutcomeForm({
     state.ui.viewport.scale
   )
   store.dispatch(
-    // ASSUMPTION: one parent (
     openOutcomeForm(calcedPoint.x, calcedPoint.y, null, fromAddress, relation)
   )
 }
@@ -535,7 +533,6 @@ export default function setupEventListeners(
 
   function canvasMouseup(event: MouseEvent) {
     const state = store.getState()
-    // ASSUMPTION: one parent (
     const { fromAddress, relation, toAddress } = state.ui.outcomeConnector
     const { activeProject } = state.ui
     if (fromAddress) {

--- a/web/src/event-listeners/index.ts
+++ b/web/src/event-listeners/index.ts
@@ -151,84 +151,88 @@ export default function setupEventListeners(
         }
         break
 
+      // DISABLED: navigating with keyboard
       // Used for navigating to a child
-      case 'ArrowDown':
-        if (
-          state.ui.selection.selectedOutcomes.length === 1 &&
-          !state.ui.outcomeForm.isOpen &&
-          !state.ui.expandedView.isOpen
-        ) {
-          const selectedOutcome = state.ui.selection.selectedOutcomes[0]
-          const childActionHash = findFirstChildActionHash(
-            selectedOutcome,
-            state
-          )
-          if (childActionHash) {
-            // select and pan and zoom to
-            // the parent
-            store.dispatch(animatePanAndZoom(childActionHash, false))
-          }
-        }
-        break
+      // case 'ArrowDown':
+      //   if (
+      //     state.ui.selection.selectedOutcomes.length === 1 &&
+      //     !state.ui.outcomeForm.isOpen &&
+      //     !state.ui.expandedView.isOpen
+      //   ) {
+      //     const selectedOutcome = state.ui.selection.selectedOutcomes[0]
+      //     const childActionHash = findFirstChildActionHash(
+      //       selectedOutcome,
+      //       state
+      //     )
+      //     if (childActionHash) {
+      //       // select and pan and zoom to
+      //       // the parent
+      //       store.dispatch(animatePanAndZoom(childActionHash, false))
+      //     }
+      //   }
+      //   break
 
+      // DISABLED: navigating with keyboard
       // Used for navigating to a parent
-      case 'ArrowUp':
-        if (
-          state.ui.selection.selectedOutcomes.length === 1 &&
-          !state.ui.outcomeForm.isOpen &&
-          !state.ui.expandedView.isOpen
-        ) {
-          const selectedOutcome = state.ui.selection.selectedOutcomes[0]
-          const parentActionHash = findParentActionHash(selectedOutcome, state)
-          if (parentActionHash) {
-            // select and pan and zoom to
-            // the parent
-            store.dispatch(animatePanAndZoom(parentActionHash, false))
-          }
-        }
-        break
+      // case 'ArrowUp':
+      //   if (
+      //     state.ui.selection.selectedOutcomes.length === 1 &&
+      //     !state.ui.outcomeForm.isOpen &&
+      //     !state.ui.expandedView.isOpen
+      //   ) {
+      //     const selectedOutcome = state.ui.selection.selectedOutcomes[0]
+      //     const parentActionHash = findParentActionHash(selectedOutcome, state)
+      //     if (parentActionHash) {
+      //       // select and pan and zoom to
+      //       // the parent
+      //       store.dispatch(animatePanAndZoom(parentActionHash, false))
+      //     }
+      //   }
+      //   break
 
+      // DISABLED: navigating with keyboard
       // Used for navigating to the left sibling
-      case 'ArrowLeft':
-        if (
-          state.ui.selection.selectedOutcomes.length === 1 &&
-          !state.ui.outcomeForm.isOpen &&
-          !state.ui.expandedView.isOpen
-        ) {
-          const selectedOutcome = state.ui.selection.selectedOutcomes[0]
-          const targetActionHash = findSiblingActionHash(
-            selectedOutcome,
-            state,
-            RightOrLeft.Left
-          )
-          if (targetActionHash) {
-            // select and pan and zoom to
-            // the parent
-            store.dispatch(animatePanAndZoom(targetActionHash, false))
-          }
-        }
-        break
+      // case 'ArrowLeft':
+      //   if (
+      //     state.ui.selection.selectedOutcomes.length === 1 &&
+      //     !state.ui.outcomeForm.isOpen &&
+      //     !state.ui.expandedView.isOpen
+      //   ) {
+      //     const selectedOutcome = state.ui.selection.selectedOutcomes[0]
+      //     const targetActionHash = findSiblingActionHash(
+      //       selectedOutcome,
+      //       state,
+      //       RightOrLeft.Left
+      //     )
+      //     if (targetActionHash) {
+      //       // select and pan and zoom to
+      //       // the parent
+      //       store.dispatch(animatePanAndZoom(targetActionHash, false))
+      //     }
+      //   }
+      //   break
 
+      // DISABLED: navigating with keyboard
       // Used for navigating to the right sibling
-      case 'ArrowRight':
-        if (
-          state.ui.selection.selectedOutcomes.length === 1 &&
-          !state.ui.outcomeForm.isOpen &&
-          !state.ui.expandedView.isOpen
-        ) {
-          const selectedOutcome = state.ui.selection.selectedOutcomes[0]
-          const targetActionHash = findSiblingActionHash(
-            selectedOutcome,
-            state,
-            RightOrLeft.Right
-          )
-          if (targetActionHash) {
-            // select and pan and zoom to
-            // the parent
-            store.dispatch(animatePanAndZoom(targetActionHash, false))
-          }
-        }
-        break
+      // case 'ArrowRight':
+      //   if (
+      //     state.ui.selection.selectedOutcomes.length === 1 &&
+      //     !state.ui.outcomeForm.isOpen &&
+      //     !state.ui.expandedView.isOpen
+      //   ) {
+      //     const selectedOutcome = state.ui.selection.selectedOutcomes[0]
+      //     const targetActionHash = findSiblingActionHash(
+      //       selectedOutcome,
+      //       state,
+      //       RightOrLeft.Right
+      //     )
+      //     if (targetActionHash) {
+      //       // select and pan and zoom to
+      //       // the parent
+      //       store.dispatch(animatePanAndZoom(targetActionHash, false))
+      //     }
+      //   }
+      //   break
 
       // Used in multi selecting Outcomes
       case 'Shift':

--- a/web/src/redux/ephemeral/animations/getGraphForState.ts
+++ b/web/src/redux/ephemeral/animations/getGraphForState.ts
@@ -1,16 +1,16 @@
-import { ProjectComputedOutcomes } from '../../../context/ComputedOutcomeContext'
-import outcomesAsTrees, {
-  TreeData,
+import outcomesAsGraph, {
+  Graph,
+  GraphData,
 } from '../../persistent/projects/outcomes/outcomesAsTrees'
 import { RootState } from '../../reducer'
 
-export function getTreesForState(state: RootState): ProjectComputedOutcomes {
+export function getGraphForState(state: RootState): Graph {
   const projectId = state.ui.activeProject
-  const graphData: TreeData = {
+  const graphData: GraphData = {
     outcomes: state.projects.outcomes[projectId] || {},
     connections: state.projects.connections[projectId] || {},
     outcomeMembers: state.projects.outcomeMembers[projectId] || {},
     agents: state.agents,
   }
-  return outcomesAsTrees(graphData, { withMembers: true })
+  return outcomesAsGraph(graphData, { withMembers: true })
 }

--- a/web/src/redux/ephemeral/animations/getGraphForState.ts
+++ b/web/src/redux/ephemeral/animations/getGraphForState.ts
@@ -1,7 +1,7 @@
 import outcomesAsGraph, {
   Graph,
   GraphData,
-} from '../../persistent/projects/outcomes/outcomesAsTrees'
+} from '../../persistent/projects/outcomes/outcomesAsGraph'
 import { RootState } from '../../reducer'
 
 export function getGraphForState(state: RootState): Graph {

--- a/web/src/redux/ephemeral/animations/layout.ts
+++ b/web/src/redux/ephemeral/animations/layout.ts
@@ -5,7 +5,7 @@ import layoutFormula from '../../../drawing/layoutFormula'
 import { RootState } from '../../reducer'
 import { LAYOUT_ANIMATION_DURATION_MS } from '../../../constants'
 import { ComputedOutcome } from '../../../types'
-import { getTreesForState } from './get-trees-for-state'
+import { getGraphForState } from './getGraphForState'
 import { coordsCanvasToPage } from '../../../drawing/coordinateSystems'
 import { ActionHashB64 } from '../../../types/shared'
 import { CoordinatesState, DimensionsState } from '../layout/state-type'
@@ -55,7 +55,7 @@ export default function performLayoutAnimation(
   // called nextState because by now the
   // initial action has been integrated
   const nextState: RootState = store.getState()
-  const computedOutcomeTrees = getTreesForState(nextState)
+  const graph = getGraphForState(nextState)
   const zoomLevel = nextState.ui.viewport.scale
   const translate = nextState.ui.viewport.translate
   const projectId = nextState.ui.activeProject
@@ -71,7 +71,7 @@ export default function performLayoutAnimation(
   // this is our final destination layout
   // that we'll be animating to
   const newLayout = layoutFormula(
-    computedOutcomeTrees,
+    graph,
     zoomLevel,
     projectTags,
     collapsedOutcomes,

--- a/web/src/redux/ephemeral/animations/pan-and-zoom.ts
+++ b/web/src/redux/ephemeral/animations/pan-and-zoom.ts
@@ -6,7 +6,7 @@ import { RootState } from '../../reducer'
 import { updateLayout } from '../layout/actions'
 import { selectOutcome, unselectAll } from '../selection/actions'
 import { changeAllDirect } from '../viewport/actions'
-import { getTreesForState } from './get-trees-for-state'
+import { getGraphForState } from './getGraphForState'
 
 /*
   In this function as we animate the "pan and zoom", or "translate and scale"
@@ -38,7 +38,7 @@ export default function panZoomToFrame(
     : state.ui.viewport.scale
 
   const { activeProject } = state.ui
-  const outcomeTrees = getTreesForState(state)
+  const graph = getGraphForState(state)
 
   const projectTags = Object.values(state.projects.tags[activeProject] || {})
   const hiddenSmallOutcomes = state.ui.mapViewSettings.hiddenSmallOutcomes
@@ -52,12 +52,12 @@ export default function panZoomToFrame(
   // that we'll be animating to
   // use the target zoomLevel
   const newLayout = layoutFormula(
-    outcomeTrees,
+    graph,
     zoomLevel,
     projectTags,
     collapsedOutcomes,
     hiddenSmalls,
-    hiddenAchieved,
+    hiddenAchieved
   )
 
   // this accounts for a special case where the caller doesn't
@@ -65,11 +65,11 @@ export default function panZoomToFrame(
   // function to pick the best one
   if (!outcomeActionHash) {
     // pick the first parent to center on
-    outcomeActionHash = (outcomeTrees.computedOutcomesAsTree[0] || {})
+    outcomeActionHash = (graph.outcomes.computedOutcomesAsTree[0] || {})
       .actionHash
   }
 
-  const outcome = outcomeTrees.computedOutcomesKeyed[outcomeActionHash]
+  const outcome = graph.outcomes.computedOutcomesKeyed[outcomeActionHash]
   // important, for the outcomeCoordinates we should
   // definitely choose them from the new intended layout,
   // not the existing one

--- a/web/src/redux/ephemeral/outcome-connector/actions.ts
+++ b/web/src/redux/ephemeral/outcome-connector/actions.ts
@@ -11,7 +11,7 @@ const RELATION_AS_PARENT = RelationInput.ExistingOutcomeAsParent
 const RELATION_AS_CHILD = RelationInput.ExistingOutcomeAsChild
 
 // relation should be RELATION_AS_PARENT or RELATION_AS_CHILD
-// existingParentConnectionAddress is optional
+//
 function setOutcomeConnectorFrom(
   actionHash: ActionHashB64,
   relation: RelationInput,
@@ -24,7 +24,6 @@ function setOutcomeConnectorFrom(
       address: actionHash, // TODO: rename
       relation,
       validToAddresses: validToActionHashes,
-      existingParentConnectionAddress: existingParentConnectionActionHash,
     },
   }
 }

--- a/web/src/redux/ephemeral/outcome-connector/handler.js
+++ b/web/src/redux/ephemeral/outcome-connector/handler.js
@@ -1,5 +1,8 @@
 import { RELATION_AS_PARENT, resetOutcomeConnector } from './actions'
-import { createConnection, deleteConnection } from '../../persistent/projects/connections/actions'
+import {
+  createConnection,
+  deleteConnection,
+} from '../../persistent/projects/connections/actions'
 import ProjectsZomeApi from '../../../api/projectsApi'
 import { getAppWs } from '../../../hcWebsockets'
 import { cellIdFromString } from '../../../utils'
@@ -17,26 +20,17 @@ export default async function handleConnectionConnectMouseUp(
   const appWebsocket = await getAppWs()
   const projectsZomeApi = new ProjectsZomeApi(appWebsocket)
   if (fromAddress && toAddress) {
-    // if we are replacing an connection with this one
-    // delete the existing connection first
-    // ASSUMPTION: one parent
-    if (existingParentConnectionAddress) {
-      // don't trigger TRIGGER_LAYOUT_UPDATE here
-      // because we will only be archiving
-      // an connection here in the context of immediately replacing
-      // it with another
-      await projectsZomeApi.connection.delete(cellId, existingParentConnectionAddress)
-      dispatch(deleteConnection(activeProject, existingParentConnectionAddress))
-    }
-
     const fromAsParent = relation === RELATION_AS_PARENT
     const createdConnection = await projectsZomeApi.connection.create(cellId, {
-        parentActionHash: fromAsParent ? fromAddress : toAddress,
-        childActionHash: fromAsParent ? toAddress : fromAddress,
-        randomizer: Date.now(),
-        isImported: false
-      })
-    const createConnectionAction = createConnection(activeProject, createdConnection)
+      parentActionHash: fromAsParent ? fromAddress : toAddress,
+      childActionHash: fromAsParent ? toAddress : fromAddress,
+      randomizer: Date.now(),
+      isImported: false,
+    })
+    const createConnectionAction = createConnection(
+      activeProject,
+      createdConnection
+    )
     dispatch(createConnectionAction)
   }
   dispatch(resetOutcomeConnector())

--- a/web/src/redux/ephemeral/outcome-connector/handler.js
+++ b/web/src/redux/ephemeral/outcome-connector/handler.js
@@ -11,8 +11,6 @@ export default async function handleConnectionConnectMouseUp(
   fromAddress,
   relation,
   toAddress,
-  // ASSUMPTION: one parent
-  existingParentConnectionAddress,
   activeProject,
   dispatch
 ) {

--- a/web/src/redux/ephemeral/outcome-connector/reducer.js
+++ b/web/src/redux/ephemeral/outcome-connector/reducer.js
@@ -10,10 +10,9 @@ const defaultState = {
   relation: null,
   validToAddresses: [],
   toAddress: null,
-  // existingParentConnectionAddress is the actionHash of the connection that
+  //
   // we would delete in order to create a new one
   // ASSUMPTION: one parent
-  existingParentConnectionAddress: null
 }
 
 export default function reducer(state = defaultState, action) {
@@ -26,7 +25,6 @@ export default function reducer(state = defaultState, action) {
         relation: payload.relation,
         validToAddresses: payload.validToAddresses,
         // ASSUMPTION: one parent
-        existingParentConnectionAddress: payload.existingParentConnectionAddress
       }
     case SET_CONNECTION_CONNECTOR_TO:
       return {

--- a/web/src/redux/ephemeral/outcome-connector/reducer.js
+++ b/web/src/redux/ephemeral/outcome-connector/reducer.js
@@ -10,9 +10,6 @@ const defaultState = {
   relation: null,
   validToAddresses: [],
   toAddress: null,
-  //
-  // we would delete in order to create a new one
-  // ASSUMPTION: one parent
 }
 
 export default function reducer(state = defaultState, action) {
@@ -24,7 +21,6 @@ export default function reducer(state = defaultState, action) {
         fromAddress: payload.address,
         relation: payload.relation,
         validToAddresses: payload.validToAddresses,
-        // ASSUMPTION: one parent
       }
     case SET_CONNECTION_CONNECTOR_TO:
       return {

--- a/web/src/redux/ephemeral/outcome-form/actions.js
+++ b/web/src/redux/ephemeral/outcome-form/actions.js
@@ -14,7 +14,6 @@ const UPDATE_CONTENT = 'UPDATE_CONTENT'
 
 // fromAddress and relation are optional
 // but should be passed together
-// ASSUMPTION: one parent (
 function openOutcomeForm(x, y, editAddress, fromAddress, relation) {
   return {
     type: OPEN_OUTCOME_FORM,
@@ -24,7 +23,6 @@ function openOutcomeForm(x, y, editAddress, fromAddress, relation) {
       y,
       fromAddress,
       relation,
-      // ASSUMPTION: one parent (
     },
   }
 }

--- a/web/src/redux/ephemeral/outcome-form/actions.js
+++ b/web/src/redux/ephemeral/outcome-form/actions.js
@@ -14,8 +14,8 @@ const UPDATE_CONTENT = 'UPDATE_CONTENT'
 
 // fromAddress and relation are optional
 // but should be passed together
-// ASSUMPTION: one parent (existingParentConnectionAddress)
-function openOutcomeForm(x, y, editAddress, fromAddress, relation, existingParentConnectionAddress) {
+// ASSUMPTION: one parent (
+function openOutcomeForm(x, y, editAddress, fromAddress, relation) {
   return {
     type: OPEN_OUTCOME_FORM,
     payload: {
@@ -24,8 +24,7 @@ function openOutcomeForm(x, y, editAddress, fromAddress, relation, existingParen
       y,
       fromAddress,
       relation,
-      // ASSUMPTION: one parent (existingParentConnectionAddress)
-      existingParentConnectionAddress,
+      // ASSUMPTION: one parent (
     },
   }
 }

--- a/web/src/redux/ephemeral/outcome-form/reducer.js
+++ b/web/src/redux/ephemeral/outcome-form/reducer.js
@@ -18,9 +18,6 @@ const defaultState = {
   // and relation indicates the 'port' in a sense, to be parent or child
   fromAddress: null,
   relation: null, // RELATION_AS_CHILD or RELATION_AS_PARENT
-  //
-  // we would delete in order to create a new one
-  // ASSUMPTION: one parent
 }
 
 export default function (state = defaultState, action) {
@@ -34,7 +31,6 @@ export default function (state = defaultState, action) {
     // these three go together
     fromAddress: null,
     relation: null,
-    // ASSUMPTION: one parent
   }
 
   switch (type) {
@@ -55,7 +51,6 @@ export default function (state = defaultState, action) {
         // these three go together
         fromAddress: payload.fromAddress,
         relation: payload.relation,
-        // ASSUMPTION: one parent
       }
     case CLOSE_OUTCOME_FORM:
       return resetVersion

--- a/web/src/redux/ephemeral/outcome-form/reducer.js
+++ b/web/src/redux/ephemeral/outcome-form/reducer.js
@@ -1,6 +1,8 @@
-
-
-import { OPEN_OUTCOME_FORM, CLOSE_OUTCOME_FORM, UPDATE_CONTENT } from './actions'
+import {
+  OPEN_OUTCOME_FORM,
+  CLOSE_OUTCOME_FORM,
+  UPDATE_CONTENT,
+} from './actions'
 
 import { DELETE_OUTCOME_FULLY } from '../../persistent/projects/outcomes/actions'
 
@@ -11,15 +13,14 @@ const defaultState = {
   leftConnectionXPosition: 0,
   topConnectionYPosition: 0,
   // these three go together
-  // where the fromAddress is the actionHash of the 
+  // where the fromAddress is the actionHash of the
   // Outcome that is the 'origin' of the connection
   // and relation indicates the 'port' in a sense, to be parent or child
   fromAddress: null,
   relation: null, // RELATION_AS_CHILD or RELATION_AS_PARENT
-  // existingParentConnectionAddress is the actionHash of the connection that
+  //
   // we would delete in order to create a new one
   // ASSUMPTION: one parent
-  existingParentConnectionAddress: null, // this is optional though
 }
 
 export default function (state = defaultState, action) {
@@ -34,7 +35,6 @@ export default function (state = defaultState, action) {
     fromAddress: null,
     relation: null,
     // ASSUMPTION: one parent
-    existingParentConnectionAddress: null // this is optional though
   }
 
   switch (type) {
@@ -56,7 +56,6 @@ export default function (state = defaultState, action) {
         fromAddress: payload.fromAddress,
         relation: payload.relation,
         // ASSUMPTION: one parent
-        existingParentConnectionAddress: payload.existingParentConnectionAddress, // this is optional though
       }
     case CLOSE_OUTCOME_FORM:
       return resetVersion

--- a/web/src/redux/persistent/projects/outcomes/outcomesAsGraph.ts
+++ b/web/src/redux/persistent/projects/outcomes/outcomesAsGraph.ts
@@ -10,7 +10,7 @@ import { ProjectOutcomeVotesState } from '../outcome-votes/reducer'
 import { computeAchievementStatus, computeScope } from './computedState'
 import { ProjectOutcomesState } from './reducer'
 
-export type TreeData = {
+export type GraphData = {
   outcomes: ProjectOutcomesState
   connections: ProjectConnectionsState
   agents?: AgentsState
@@ -19,10 +19,14 @@ export type TreeData = {
   outcomeComments?: ProjectOutcomeCommentsState
 }
 
-export default function outcomesAsTrees(
-  treeData: TreeData,
+export type Graph = {
+  outcomes: ProjectComputedOutcomes
+  connections: ProjectConnectionsState
+}
+export default function outcomesAsGraph(
+  graphData: GraphData,
   { withMembers = false, withComments = false, withVotes = false } = {}
-): ProjectComputedOutcomes {
+): Graph {
   const {
     outcomes,
     connections,
@@ -30,7 +34,7 @@ export default function outcomesAsTrees(
     outcomeVotes,
     outcomeComments,
     agents,
-  } = treeData
+  } = graphData
 
   // modify so that all outcomes have their related things, if in opts
   let allOutcomes = outcomes
@@ -105,7 +109,10 @@ export default function outcomesAsTrees(
   const computedOutcomesAsTree = noParentsAddresses.map(getOutcome)
 
   return {
-    computedOutcomesAsTree,
-    computedOutcomesKeyed,
+    outcomes: {
+      computedOutcomesAsTree,
+      computedOutcomesKeyed,
+    },
+    connections,
   }
 }

--- a/web/src/selectors/computeOutcomes.ts
+++ b/web/src/selectors/computeOutcomes.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect'
-import outcomesAsTrees from '../redux/persistent/projects/outcomes/outcomesAsTrees'
+import outcomesAsGraph from '../redux/persistent/projects/outcomes/outcomesAsGraph'
 import { RootState } from '../redux/reducer'
 
 const selectAndComputeOutcomes = createSelector(
@@ -28,7 +28,8 @@ const selectAndComputeOutcomes = createSelector(
       outcomeVotes: {},
       outcomeComments: {},
     }
-    const outcomeTrees = outcomesAsTrees(treeData, { withMembers: true })
+    const outcomeTrees = outcomesAsGraph(treeData, { withMembers: true })
+      .outcomes
     return outcomeTrees
   }
 )

--- a/web/src/tree-logic.ts
+++ b/web/src/tree-logic.ts
@@ -81,14 +81,11 @@ function calculateValidChildren(
 ) {
   return outcomeActionHashes.filter((outcomeActionHash) => {
     return (
-      // filter out self-address in the process
+      // filter out self
       outcomeActionHash !== fromAddress &&
-      // find the Outcome objects without parent Outcomes
-      // since they will sit at the top level
-      !connections.find(
-        (connection) => connection.childActionHash === outcomeActionHash
-      ) &&
-      !isAncestor(fromAddress, outcomeActionHash, connections)
+      // find the Outcome objects that are not descendants of the fromAddress
+      // since we don't want to create cycles
+      !isAncestor(outcomeActionHash, fromAddress, connections)
     )
   })
 }


### PR DESCRIPTION
Closes #202.

Outcomes can now have multiple parents. To achieve this, a large refactor with the way we are calculating the coordinates for each outcome was necessary. Previously a `tree` structure was assumed in the layout, which meant that any Outcome was assumed to only have a single parent.

The new data structure for calculating the coordinates is a `Directed Acyclic Graph (dag)`. The dag structure behaves almost identically to the old tree structure, but without this underlying assumption.

Unfortunately, this means that 2 features had to be disabled until further notice:
1. Collapsing outcomes. Due to the nature of the dag structure, some ambiguity arose as to how to handle collapsing outcomes. Specifically in cases where some number of parents of an outcome are collapsed. There are solutions to this problem, but all of them are opinionated and could result in a jarring UX.
2. Keyboard navigation. Again, having multiple parents has introduced some ambiguity as to where the camera should pan and zoom to. For example: If you are selecting an outcome with multiple parents, and you press the `up` arrow key, which parent should the camera pan to?

Appending a new parent generally involves dragging from the top anchor point of an Outcome to either create a new parent or to attach to an existing outcome.

This marks my first contribution to the project. Please let me know your thoughts, and if you have any concerns or suggestions, I'd love to hear them!