### PR TITLE
Lower zoom thresholds for placeholder cards

### DIFF
--- a/web/src/drawing/dimensions.ts
+++ b/web/src/drawing/dimensions.ts
@@ -141,7 +141,10 @@ function getLines({
     const endofSplitWord = word.slice(wordMustBeBrokenAtIndex)
     // if its still too big, recurse, split again
     // as long as its not recursing too deep
-    if (ctx.measureText(endofSplitWord).width > maxWidth && recursions < RECURSE_MAX) {
+    if (
+      ctx.measureText(endofSplitWord).width > maxWidth &&
+      recursions < RECURSE_MAX
+    ) {
       currentLine = ''
       splitWordFit(endofSplitWord, recursions + 1)
     } else {

--- a/web/src/drawing/drawOutcome/computeArguments/argsForDrawStatement.ts
+++ b/web/src/drawing/drawOutcome/computeArguments/argsForDrawStatement.ts
@@ -49,14 +49,14 @@ export const argsForDrawStatement = ({
   const statementPlaceholder = noStatementPlaceholder
     ? false
     : outcome
-    ? (outcome.computedScope === ComputedScope.Small && zoomLevel <= 0.5) ||
-      (outcome.computedScope !== ComputedScope.Small && zoomLevel <= 0.25)
+    ? (outcome.computedScope === ComputedScope.Small && zoomLevel <= 0.4) ||
+      (outcome.computedScope !== ComputedScope.Small && zoomLevel <= 0.2)
     : false
 
   skipRender =
     skipRender ||
     (outcome
-      ? outcome.computedScope === ComputedScope.Small && zoomLevel <= 0.3
+      ? outcome.computedScope === ComputedScope.Small && zoomLevel <= 0.25
       : false)
 
   // statement placeholder line heights depending on outcome scope


### PR DESCRIPTION
Closes #242.

Lowers the thresholds for replacing text with placeholders to something more appropriate. The thresholds were adjusted as follows:
* Small outcomes: Replace text with placeholder text at 40%, down from 50%.
    * Stop rendering information on the card at all at 25%, down from 30%.
* Non-small outcomes: Replace text with placeholder text at 20%, down from 25%.