### PR TITLE
Refactor Github Workflows to no longer use Nix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,21 +34,8 @@ jobs:
             .cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Use Nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-21.05
-      - name: Configure Nix substituters
-        run: |
-          set -xe
-          mkdir -p ~/.config/nix/
-          cp ./.github/nix.conf ~/.config/nix/
-      - name: Use cachix
-        uses: cachix/cachix-action@v12
-        with:
-          name: holochain-ci
-      - name: Prepare Nix environment
-        run: nix-shell --command "echo Completed"
+      - name: Install holochain_cli
+        run: cargo install holochain_cli --version 0.1.0 --locked
        # build hApp
       - name: Build hApp
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: taiki-e/create-gh-release-action@v1
+      - uses: dtolnay/rust-toolchain@1.65
         env:
           # (required)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ jobs:
         run: cargo install holochain_cli --version 0.1.0 --locked
        # build hApp
       - name: Build hApp
-        run: |
-          nix-shell --run "npm run happ-pack"
+        run: bash ./scripts/happ-pack.sh
       # store happs as build artifacts
       - uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.65
+        with:
+          targets: wasm32-unknown-unknown
       - name: Install holochain_cli
         run: cargo install holochain_cli --version 0.1.0 --locked
        # build hApp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.65
+      - uses: taiki-e/create-gh-release-action@v1
         env:
           # (required)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -21,19 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            .cargo/bin/
-            .cargo/registry/index/
-            .cargo/registry/cache/
-            .cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install holochain_cli
         run: cargo install holochain_cli --version 0.1.0 --locked
        # build hApp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,24 @@
 # Disabled for now, to not waste CI resources
 
-name: Cargo tests
-
-on: [ push, pull_request ]
-
-jobs:
-  cargo_test:
-    runs-on: ubuntu-latest
-
-    steps:
-     - uses: actions/checkout@v3
-     - uses: dtolnay/rust-toolchain@1.65
-       with:
-         targets: wasm32-unknown-unknown
-
-     - run: rustc --version
-     - run: cargo --version
-     - run: rustup component list --installed
-     - run: rustup show
-
-     - run: cargo install holochain_cli --version 0.1.0 --locked
-     - run: bash ./scripts/happ-pack.sh
+# name: Cargo tests
+#
+# on: [ push, pull_request ]
+#
+# jobs:
+#   cargo_test:
+#     runs-on: ubuntu-latest
+#
+#     steps:
+#      - uses: actions/checkout@v3
+#      - uses: dtolnay/rust-toolchain@1.65
+#        with:
+#          targets: wasm32-unknown-unknown
+#
+#      - run: rustc --version
+#      - run: cargo --version
+#      - run: rustup component list --installed
+#      - run: rustup show
+#
+#      - run: cargo install holochain_cli --version 0.1.0 --locked
+#      - run: bash ./scripts/happ-pack.sh
+#

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
      - uses: actions/checkout@v3
      - uses: actions-rs/toolchain@v1
        with:
-         toolchain: 1.69
+         toolchain: 1.65
          target: wasm32-unknown-unknown
 
      - run: rustc --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,4 @@ jobs:
      - run: rustup show
 
      - run: cargo install holochain_cli --version 0.1.0 --locked
-     - run: ./scripts/happ-pack.sh
+     - run: bash ./scripts/happ-pack.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,8 @@ jobs:
 
     steps:
      - uses: actions/checkout@v3
-     - uses: dtolnay/rust-toolchain@stable
+     - uses: dtolnay/rust-toolchain@1.65
        with:
-         toolchain: 1.65
          targets: wasm32-unknown-unknown
 
      - run: rustc --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,25 @@
 # Disabled for now, to not waste CI resources
 
-# name: Cargo tests
+name: Cargo tests
 
-# on: [ push, pull_request ]
+on: [ push, pull_request ]
 
-# jobs:
-#   cargo_test:
-#     runs-on: ubuntu-latest
+jobs:
+  cargo_test:
+    runs-on: ubuntu-latest
 
-#     steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: 1.58
-#          target: wasm32-unknown-unknown
+    steps:
+     - uses: actions/checkout@v2
+     - uses: actions-rs/toolchain@v1
+       with:
+         toolchain: 1.58
+         target: wasm32-unknown-unknown
 
-#      - run: rustup update stable
-#      - run: rustc --version
-#      - run: cargo --version
-#      - run: rustup component list --installed
-#      - run: rustup show
+     - run: rustup update stable
+     - run: rustc --version
+     - run: cargo --version
+     - run: rustup component list --installed
+     - run: rustup show
 
-#      - run: ./scripts/happ-test.sh
+     - run: ./scripts/happ-test.sh
+     - run: cargo install holochain_cli --version 0.1.0 --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
      - uses: actions/checkout@v3
-     - uses: actions-rs/toolchain@v1
+     - uses: dtolnay/rust-toolchain@stable
        with:
          toolchain: 1.65
-         target: wasm32-unknown-unknown
+         targets: wasm32-unknown-unknown
 
      - run: rustc --version
      - run: cargo --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-     - uses: actions/checkout@v2
+     - uses: actions/checkout@v3
      - uses: actions-rs/toolchain@v1
        with:
          toolchain: 1.58

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,4 @@ jobs:
      - run: rustup component list --installed
      - run: rustup show
 
-     - run: ./scripts/happ-test.sh
      - run: cargo install holochain_cli --version 0.1.0 --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
      - uses: actions/checkout@v3
      - uses: actions-rs/toolchain@v1
        with:
-         toolchain: 1.58
+         toolchain: 1.69
          target: wasm32-unknown-unknown
 
-     - run: rustup update stable
      - run: rustc --version
      - run: cargo --version
      - run: rustup component list --installed
      - run: rustup show
 
      - run: cargo install holochain_cli --version 0.1.0 --locked
+     - run: ./scripts/happ-pack.sh


### PR DESCRIPTION
Replace usage of cachix and nix with direct calls to `cargo install` and bash scripts. This should shave off some time during CI and allow us to release faster.