### PR TITLE
keep user on a relevant tab after the scope changes

### DIFF
--- a/web/src/components/ExpandedViewMode/ExpandedViewMode.component.tsx
+++ b/web/src/components/ExpandedViewMode/ExpandedViewMode.component.tsx
@@ -73,6 +73,18 @@ const ExpandedViewMode: React.FC<ExpandedViewModeProps> = ({
     }
   }, [outcomeActionHash])
 
+  useEffect(() => {
+    if (outcome) {
+      // make sure that a section that isn't available, based on changes
+      // to the Outcome, isn't shown
+      if ('Small' in outcome.scope && activeTab === ExpandedViewTab.ChildrenList) {
+        setActiveTab(ExpandedViewTab.TaskList)
+      } else if ('Uncertain' in outcome.scope && activeTab === ExpandedViewTab.TaskList) {
+        setActiveTab(ExpandedViewTab.ChildrenList)
+      }
+    }
+  }, [outcome, activeTab, setActiveTab])
+
   const outcomeId = hashCodeId(outcomeActionHash)
 
   // if not small, then show children list icon on left menu

--- a/web/src/components/MapViewCreateOutcome/MapViewCreateOutcome.component.tsx
+++ b/web/src/components/MapViewCreateOutcome/MapViewCreateOutcome.component.tsx
@@ -3,14 +3,6 @@ import useOnClickOutside from 'use-onclickoutside'
 import TextareaAutosize from 'react-textarea-autosize'
 import moment from 'moment'
 
-import {
-  firstZoomThreshold,
-  fontSize,
-  fontSizeExtraLarge,
-  fontSizeLarge,
-  lineHeightMultiplier,
-  secondZoomThreshold,
-} from '../../drawing/dimensions'
 import './MapViewCreateOutcome.scss'
 import {
   AgentPubKeyB64,
@@ -18,8 +10,7 @@ import {
   ActionHashB64,
   Option,
 } from '../../types/shared'
-import { LinkedOutcomeDetails, Outcome, RelationInput } from '../../types'
-import Checkbox from '../Checkbox/Checkbox'
+import { LinkedOutcomeDetails, Outcome } from '../../types'
 import ButtonCheckbox from '../ButtonCheckbox/ButtonCheckbox'
 import { coordsCanvasToPage } from '../../drawing/coordinateSystems'
 import Icon from '../Icon/Icon'


### PR DESCRIPTION
fixes #212