### PR TITLE
fix: Remote signals not sent to oneself anymore

### DIFF
--- a/happs/happ/zomes/projects/src/lib.rs
+++ b/happs/happ/zomes/projects/src/lib.rs
@@ -150,8 +150,9 @@ pub struct EditingOutcomeDetails {
 }
 #[hdk_extern]
 pub fn emit_realtime_info_signal(realtime_info: RealtimeInfoInput) -> ExternResult<()> {
+    let my_pubkey = agent_info()?.agent_initial_pubkey;
     let realtime_info_signal = RealtimeInfoSignal {
-        agent_pub_key: AgentPubKeyB64::new(agent_info()?.agent_initial_pubkey),
+        agent_pub_key: AgentPubKeyB64::new(my_pubkey.clone()),
         project_id: realtime_info.project_id,
         outcome_being_edited: realtime_info.outcome_being_edited,
         outcome_expanded_view: realtime_info.outcome_expanded_view,
@@ -159,7 +160,8 @@ pub fn emit_realtime_info_signal(realtime_info: RealtimeInfoInput) -> ExternResu
 
     let signal = SignalType::RealtimeInfo(realtime_info_signal);
     let payload = ExternIO::encode(signal).map_err(|e| wasm_error!(e))?;
-    let peers = get_peers_content()?;
+    let mut peers = get_peers_content()?;
+    peers.retain(|a| a != &my_pubkey);
     send_remote_signal(payload, peers)?;
     Ok(())
 }

--- a/weave-tool/.kitsune2_bootstrap_srv
+++ b/weave-tool/.kitsune2_bootstrap_srv
@@ -1,0 +1,1 @@
+{"bootstrapUrl":"http://127.0.0.1:44341","signalingUrl":"ws://127.0.0.1:44341"}

--- a/weave-tool/weave.dev.config.ts
+++ b/weave-tool/weave.dev.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@theweave/cli'
 export default defineConfig({
   toolCurations: [
     {
-      url: 'https://raw.githubusercontent.com/lightningrodlabs/weave-tool-curation/refs/heads/test-0.13/0.13/lists/curations-0.13.json',
+      url: 'https://lightningrodlabs.org/weave-tool-curation/0.14/curations-0.14.json',
       useLists: ['default'],
     },
   ],
@@ -78,7 +78,7 @@ export default defineConfig({
       },
       source: {
         type: 'https',
-        url: 'https://github.com/holochain-apps/kando/releases/download/v0.12.0-rc.1/kando.webhapp',
+        url: 'https://github.com/holochain-apps/kando/releases/download/v0.13.0-rc.0/kando.webhapp',
       },
     },
   ],

--- a/weave-tool/weave.dev.config.webhapp.ts
+++ b/weave-tool/weave.dev.config.webhapp.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@theweave/cli'
 export default defineConfig({
   toolCurations: [
     {
-      url: 'https://raw.githubusercontent.com/lightningrodlabs/weave-tool-curation/refs/heads/test-0.13/0.13/lists/curations-0.13.json',
+      url: 'https://lightningrodlabs.org/weave-tool-curation/0.14/curations-0.14.json',
       useLists: ['default'],
     },
   ],


### PR DESCRIPTION
Fixes a bug that would send remote signals to oneself which makes a card uneditable because it is considered as being edited by someone else.